### PR TITLE
Update snakebids.yml

### DIFF
--- a/afids_cnn/apply_workflow/config/snakebids.yml
+++ b/afids_cnn/apply_workflow/config/snakebids.yml
@@ -63,6 +63,7 @@ parse_args:
   --model:
     help: 'Path to the model to apply.'
     required: true
+    type: Path
 
  # custom command-line parameters can then be added, these will get added to the config
 


### PR DESCRIPTION
add "type: Path" to the "model" flag. This is to ensure that snakemake pick it up as a path. This becomes important when multiple paths are being provided as inputs in snakebids

I have tested with the fix and it works as expected. 
<img width="1572" alt="Screenshot 2023-10-17 at 12 40 51 PM" src="https://github.com/afids/afids-CNN/assets/46094728/4499a5f3-e859-4b18-9321-c0a2941b6bb1">
