### PR TITLE
Select specific AFIDs for training

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+#mis folders
+tensorflow/
+jobs/
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
 # afids-CNN
 Leveraging the recent release of the anatomical fiducial framework for developing an open software infrastructure to solve the landmark regression problem on 3D MRI images
 
-## Processing imaging data for training 
-1 - skull stripping
-2 - conforming image 
-3 - intensity normalization (i.e., WM to 110)
+## Preparation 
+1- install poetry and configure cache directory
+2- poetry install and shell to activate environment 
+
+## Processing imaging data for training can be found in the following repo (
+1 - rigid registraion to MNI template 
+2 - conforming image to 1mm iso res
+3 - intensity normalization (i.e., WM to 110) followed by minmax norm
 
 ## Processing landmark data (AFIDs)
 1 - extract points from landmark file (.fcsv is supported)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Leveraging the recent release of the anatomical fiducial framework for developin
 1- install poetry and configure cache directory
 2- poetry install and shell to activate environment 
 
-## Processing imaging data for training can be found in the following repo (
+## Processing imaging data for training can be found in the following repo (https://github.com/afids/autoafids_prep)
 1 - rigid registraion to MNI template 
 2 - conforming image to 1mm iso res
 3 - intensity normalization (i.e., WM to 110) followed by minmax norm

--- a/afids_cnn/apply.py
+++ b/afids_cnn/apply.py
@@ -121,13 +121,13 @@ def process_distances(
     slices = gen_patch_slices(mni_fid, radius)
     new_pred[slices[0], slices[1], slices[2]] = arr_dis
     transformed = np.exp(-0.5 * new_pred)
-    thresh = np.percentile(transformed, 99.999)
+    thresh = np.percentile(transformed, 99)
     thresholded = transformed
     thresholded[thresholded < thresh] = 0
-    thresholded = (thresholded * 1000).astype(int)
+    thresholded = (thresholded * 1000000).astype(int)
     new = skimage.measure.regionprops(thresholded)
     if not new:
-        logger.warning("No centroid found for this afid. Results will be suspect.")
+        logger.warning("No centroid found for this afid. Results may be suspect.")
         return np.array(
             np.unravel_index(
                 np.argmax(transformed, axis=None),
@@ -157,19 +157,21 @@ def apply_model(
         resample_size=1,
         padding=0,
     )
-    normalized = min_max_normalize(img.get_fdata())
+    img_data = img.get_fdata()
     distances = predict_distances(
         radius,
         model,
         mni_fid_resampled,
-        normalized,
+        img_data,
     )
     fid_resampled = process_distances(
         distances,
-        normalized,
+        img_data,
         mni_fid_resampled,
         radius,
     )
+    print(f'coods predicted:{fid_resampled}')
+    print(f'coods predicted:{fid_voxel2world(fid_resampled, img.affine)}')
     return fid_voxel2world(fid_resampled, img.affine)
 
 

--- a/afids_cnn/train.py
+++ b/afids_cnn/train.py
@@ -8,6 +8,7 @@ import numpy as np
 import pandas as pd
 from numpy.typing import NDArray
 from tensorflow import keras
+from keras.layers import BatchNormalization, LeakyReLU
 
 from afids_cnn.generator import customImageDataGenerator
 
@@ -42,43 +43,53 @@ def create_generator(
 
 
 def gen_conv3d_layer(
-    filters: int,
+    filters: int, 
     kernel_size: tuple[int, int, int] = (3, 3, 3),
-) -> keras.layers.Conv3D:
-    return keras.layers.Conv3D(filters, kernel_size, padding="same", activation="relu")
-
+) -> keras.layers.Layer:
+    return keras.Sequential([
+        keras.layers.Conv3D(filters, kernel_size, padding="same", kernel_initializer="he_normal"),
+        BatchNormalization(),
+        LeakyReLU(alpha=0.1)
+    ])
 
 def gen_max_pooling_layer() -> keras.layers.MaxPooling3D:
     return keras.layers.MaxPooling3D((2, 2, 2))
 
 
 def gen_transpose_layer(filters: int) -> keras.layers.Conv3DTranspose:
-    return keras.layers.Conv3DTranspose(
-        filters,
-        kernel_size=2,
-        strides=2,
-        padding="same",
+    return keras.Sequential([
+        keras.layers.Conv3DTranspose(filters, kernel_size=2, strides=2, padding="same", kernel_initializer="he_normal"),
+        BatchNormalization(),
+        LeakyReLU(alpha=0.1)
+    ])
+
+def gen_dropout_layer() -> keras.layers.Dropout:
+    return keras.layers.Dropout(
+        rate = 0.2, 
+        noise_shape=None, 
+        seed=None,
     )
 
 
 def gen_std_block(filters: int, input_):
     x = gen_conv3d_layer(filters)(input_)
-    out_layer = gen_conv3d_layer(filters)(x)
+    x = gen_conv3d_layer(filters)(x)
+    out_layer = gen_dropout_layer()(x)
     return out_layer, gen_max_pooling_layer()(out_layer)
 
 
 def gen_opposite_block(filters: int, input_, out_layer):
     x = input_
-    for _ in range(3):
+    for _ in range(2):
         x = gen_conv3d_layer(filters)(x)
+    x = gen_dropout_layer()(x)
     next_filters = filters // 2
     x = gen_transpose_layer(next_filters)(x)
-    x = gen_conv3d_layer(next_filters)(x)
     return keras.layers.Concatenate(axis=4)([out_layer, x])
 
 
 def gen_model() -> keras.Model:
-    input_layer = keras.layers.Input((None, None, None, 1))
+    input_layer = keras.layers.Input((63, 63, 63, 1))
     x = keras.layers.ZeroPadding3D(padding=((1, 0), (1, 0), (1, 0)))(input_layer)
 
     out_layer_1, x = gen_std_block(16, x)  # block 1
@@ -90,7 +101,6 @@ def gen_model() -> keras.Model:
     x = gen_conv3d_layer(256)(x)
     x = gen_conv3d_layer(256)(x)
     x = keras.layers.Conv3DTranspose(filters=128, kernel_size=2, strides=(2, 2, 2))(x)
-    x = gen_conv3d_layer(128, (2, 2, 2))(x)
     x = keras.layers.Concatenate(axis=4)([out_layer_4, x])
 
     x = gen_opposite_block(128, x, out_layer_3)  # block 5 (opposite 4)
@@ -98,8 +108,9 @@ def gen_model() -> keras.Model:
     x = gen_opposite_block(32, x, out_layer_1)  # block 7 (opposite 2)
 
     # block 8 (opposite 1)
-    for _ in range(3):
+    for _ in range(2):
         x = gen_conv3d_layer(16)(x)
+    x = gen_dropout_layer()(x)
 
     # output layer
     x = keras.layers.Cropping3D(cropping=((1, 0), (1, 0), (1, 0)), data_format=None)(x)
@@ -189,7 +200,7 @@ def main():
     )
 
     callbacks = (
-        [keras.callbacks.EarlyStopping(monitor="val_loss", patience=100)]
+        [keras.callbacks.EarlyStopping(monitor="val_loss", min_delta=0.05, patience=5)]
         if args.do_early_stopping
         else None
     )

--- a/afids_cnn/train_workflow/config/snakebids.yml
+++ b/afids_cnn/train_workflow/config/snakebids.yml
@@ -78,10 +78,13 @@ parse_args:
   --afids_dir:
     help: 'Path to a BIDS dataset with AFIDs placements corresponding to bids_dir.'
     required: True
+  --afids_num:
+    help: 'AFID(s) to train. If not specified, will train on all AFIDs.'
+    nargs: '*'
   --validation_bids_dir:
     help: 'Path to a validation BIDS dataset.'
   --validation_afids_dir:
-    help: 'Path to a BIDS dataset with AFIDs placements corresponding to validation_bids_dir'
+    help: 'Path to a BIDS dataset with AFIDs placements corresponding to validation_bids_dir.'
   --frequency:
     help: 'Augmentation frequency in voxels.'
     default: 1000

--- a/afids_cnn/train_workflow/workflow/Snakefile
+++ b/afids_cnn/train_workflow/workflow/Snakefile
@@ -270,12 +270,15 @@ rule train_model:
         "{params.do_early_stopping} "
         "{params.validation_arg} {input.combined_patch_validation} "
 
-
 rule all:
     input:
         models=expand(
             rules.train_model.output.model,
-            afid=[f"{afid:02}" for afid in range(1, 33)],
+            afid=[
+                f"{afid:02}" for afid in (
+                    list(map(int, config["afids_num"])) if config["afids_num"] else range(1, 33)
+                )
+            ],
             num_augment=config["num_augment"],
             angle_stdev=config["angle_stdev"],
             radius=config["radius"],

--- a/afids_cnn/train_workflow/workflow/Snakefile
+++ b/afids_cnn/train_workflow/workflow/Snakefile
@@ -250,6 +250,7 @@ rule train_model:
             desc="num{num_augment}angle{angle_stdev}radius{radius}freq{frequency}",
             suffix="afid-{afid}_loss.csv",
         ),
+
     params:
         num_channels=config["num_channels"],
         epochs=config["epochs"],

--- a/bash_scripts/train-cnn_scratch.sh
+++ b/bash_scripts/train-cnn_scratch.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -eo pipefail 
+source /project/ctb-akhanf/ataha24/venv_archives/virtualenvs/afids-cnn-2o1BhLKg-py3.9/bin/activate
+auto_afids_cnn_train_bids --frequency 300 --afids_dir /scratch/ataha24/afids-data/data/autoafids/train/ /scratch/ataha24/afids-data/data/autoafids/train/ /scratch/ataha24/afids-data/data/autoafids/train/training_20240205 --validation-afids-dir /scratch/ataha24/afids-data/data/autoafids/validation --validation-bids-dir /scratch/ataha24/afids-data/data/autoafids/validation participant --epochs 200 --steps-per-epoch 100 --validation-steps 100 --do_early_stopping --cores 2 --use-singularity --config containers='{c3d: "/project/6050199/akhanf/singularity/bids-apps/itksnap_v3.8.2.sif"}'

--- a/bash_scripts/train-cnn_scratch_gpu.sh
+++ b/bash_scripts/train-cnn_scratch_gpu.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -eo pipefail 
+module load cuda cudnn 
+source /scratch/ataha24/0_dev/0.afids-CNN/tensorflow/bin/activate
+auto_afids_cnn_train_bids --frequency 300 --afids_dir /scratch/ataha24/afids-data/data/autoafids/train/ /scratch/ataha24/afids-data/data/autoafids/train/ /scratch/ataha24/afids-data/data/autoafids/train/training_20240209 --validation-afids-dir /scratch/ataha24/afids-data/data/autoafids/validation --validation-bids-dir /scratch/ataha24/afids-data/data/autoafids/validation participant --epochs 200 --steps-per-epoch 100 --validation-steps 20 --do_early_stopping --cores 1 --use-singularity --config containers='{c3d: "/project/6050199/akhanf/singularity/bids-apps/itksnap_v3.8.2.sif"}'


### PR DESCRIPTION
As the title suggests, this PR introduces a flag (`--afids-num`) to the training workflow enabling the user to select specific AFID(s) for training. This may be particularly helpful when testing out the workflow or for some specific use cases. Specific AFID(s) can be selected by passing a space-separated list of the AFID numbers of interest. 

For example:

* `--afids-num 1` will perform training only on AFID 1
* `--afids-num 1 2` will perform training on AFIDs 1 and 2.

In the event this parameter is not provided, all 32 AFIDs will be trained.